### PR TITLE
fix OauthGrant#expired? for auth_grants created before Opro.require_refr...

### DIFF
--- a/app/models/opro/oauth/auth_grant.rb
+++ b/app/models/opro/oauth/auth_grant.rb
@@ -26,7 +26,7 @@ class Opro::Oauth::AuthGrant < ActiveRecord::Base
 
   def expired?
     return false unless ::Opro.require_refresh_within.present?
-    return expires_in < 0
+    return expires_in && expires_in < 0
   end
 
   def not_expired?
@@ -86,7 +86,7 @@ class Opro::Oauth::AuthGrant < ActiveRecord::Base
   # used to guarantee that we are generating unique codes, access_tokens and refresh_tokens
   def unique_token_for(field, secure_token  = SecureRandom.hex(16))
     raise "bad field" unless self.respond_to?(field)
-    auth_grant = self.class.where(field => secure_token).first    
+    auth_grant = self.class.where(field => secure_token).first
     return secure_token if auth_grant.blank?
     unique_token_for(field)
   end

--- a/test/models/opro/oauth/auth_grant_test.rb
+++ b/test/models/opro/oauth/auth_grant_test.rb
@@ -15,4 +15,12 @@ class OproAuthGrantTest < ActiveSupport::TestCase
     new_token = grant.unique_token_for(:access_token, token)
     assert_not_equal token, new_token
   end
+
+  test "no expiration without access_token expiration time" do
+    ::Opro.require_refresh_within = nil
+    grant = create_auth_grant
+    ::Opro.require_refresh_within = 1.day
+    expired = grant.expired?
+    assert !expired
+  end
 end


### PR DESCRIPTION
...esh_within is setted

Hi again!

I was playing again with your gem and just discovered a bug.

You can reproduce it by commenting `config.require_refresh_within` var in an app initializer, creating an AuthGrant and then setting `config.require_refresh_withint` to some value.

This produce an error because the `AuthGrant::access_token_expires_at` is nil and `AuthGrant#expired?` raises an error: 

```
NoMethodError (undefined method `<' for false:FalseClass):
```

I have created a unit test. I don't know if you like this aproach or you'd prefer that auth_grants always generate an access_token expiration time and only check it later in `expired?` if `::Opro.require_refresh_within.present?`. Anyway, here you have a pull request if you consider is appropiate :)

Cheers!
