### PR TITLE
Check the existing code field instead of refresh_token when generating a...

### DIFF
--- a/app/models/opro/oauth/auth_grant.rb
+++ b/app/models/opro/oauth/auth_grant.rb
@@ -80,7 +80,9 @@ class Opro::Oauth::AuthGrant < ActiveRecord::Base
   end
 
   def generate_tokens!
-    self.code, self.access_token, self.refresh_token = unique_token_for(:refresh_token), unique_token_for(:access_token), unique_token_for(:refresh_token)
+    self.code          = unique_token_for(:code)
+    self.access_token  = unique_token_for(:access_token)
+    self.refresh_token = unique_token_for(:refresh_token)
   end
 
   # used to guarantee that we are generating unique codes, access_tokens and refresh_tokens


### PR DESCRIPTION
... unique code

This looks like a copy-paste error

code was getting set to unique_token_for(:refresh_token) instead of what I think was intended, unique_token_for(:code). Probably just a copy-paste error.
