### PR TITLE
Added token_type to TokenController according to RFC

### DIFF
--- a/app/controllers/opro/oauth/token_controller.rb
+++ b/app/controllers/opro/oauth/token_controller.rb
@@ -14,6 +14,8 @@ class Opro::Oauth::TokenController < OproController
     if auth_grant.present?
       auth_grant.refresh!
       render :json => { access_token:  auth_grant.access_token,
+                        # http://tools.ietf.org/html/rfc6749#section-5.1
+                        token_type:    'bearer',
                         refresh_token: auth_grant.refresh_token,
                         expires_in:    auth_grant.expires_in }
     else


### PR DESCRIPTION
May be to obscure or useless. But a tool I was using on iOS expects to have the token_type like in the RFC.

For now it is a simple string, because thats the only type of token that opro issues for now.

Also, didn't know where It was appropriate to test it or if it was even necessary for this kind of commit.
