### PR TITLE
fix bug when setting a scope in params

### DIFF
--- a/app/controllers/opro/oauth/auth_controller.rb
+++ b/app/controllers/opro/oauth/auth_controller.rb
@@ -69,7 +69,7 @@ class Opro::Oauth::AuthController < OproController
     return default_scope if params[:scope].blank?
     scope = params[:scope].is_a?(Array) ? params[:scope] : params[:scope].split(',')
     scope = scope.map(&:downcase).map(&:strip)
-    return requested_scope & default_scope
+    return scope & default_scope
   end
 
   def default_scope


### PR DESCRIPTION
requested_scope is not declared anywhere else in code and this line throws an exception when a scope is sent in the params.  
