### PR TITLE
Proposition of updates for "Password Token Exchange" case.

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,8 +290,16 @@ If you do not wish for test, docs, or client_apps views & controllers to be avai
 ```ruby
 mount_opro_oauth :except => [:oauth_client_apps]
 ```
-
 We recommend against doing this, but we aren't your mother.
+
+If you don't need auth routes because you are only using "Password Token Exchange" you can use `except` like this:
+```ruby
+mount_opro_oauth :except => [:auth]
+```
+or if you don't need docs and tests too:
+```ruby
+mount_opro_oauth :except => [:auth, :docs, :tests]
+```
 
 
 

--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ If you do not wish for test, docs, or client_apps views & controllers to be avai
 ```ruby
 mount_opro_oauth :except => [:oauth_client_apps]
 ```
+
 We recommend against doing this, but we aren't your mother.
 
 If you don't need auth routes because you are only using "Password Token Exchange" you can use `except` like this:

--- a/lib/opro/rails/routes.rb
+++ b/lib/opro/rails/routes.rb
@@ -6,10 +6,13 @@ module ActionDispatch::Routing
       skip_routes = options[:except].is_a?(Array) ? options[:except] : [options[:except]]
       controllers = options[:controllers] || {}
 
-      oauth_new_controller = controllers[:oauth_new] || 'opro/oauth/auth'
+      unless skip_routes.include?(:auth)
+        oauth_new_controller = controllers[:oauth_new] || 'opro/oauth/auth'
+        get  'oauth/new'          => "#{oauth_new_controller}#new",  :as => 'oauth_new'
+        post 'oauth/authorize'    => 'opro/oauth/auth#create',       :as => 'oauth_authorize'
+      end
+
       oauth_token_controller = controllers[:oauth_token] || 'opro/oauth/token'
-      get  'oauth/new'          => "#{oauth_new_controller}#new",  :as => 'oauth_new'
-      post 'oauth/authorize'    => 'opro/oauth/auth#create',       :as => 'oauth_authorize'
       post 'oauth/token'        => "#{oauth_token_controller}#create",      :as => 'oauth_token', :defaults => { :format => 'json' }
 
       unless skip_routes.include?(:client_apps)


### PR DESCRIPTION
I am using opro gem and it is fantastic :)


During development I've discovered that:
in "Password Token Exchange" case where there is mobile app and user exchanges username and password for token, "auth" related pages are not in use anywhere in the process.

I've added possibility to disable those routes by adding ':auth' to 'skip_routes' options.
I think it would be useful to have this functionality in opro gem.