### PR TITLE
Fix Exception when Running in Rails 5.0

### DIFF
--- a/app/controllers/opro/oauth/token_controller.rb
+++ b/app/controllers/opro/oauth/token_controller.rb
@@ -3,7 +3,7 @@
 
 class Opro::Oauth::TokenController < OproController
   before_filter      :opro_authenticate_user!,    :except => [:create]
-  skip_before_filter :verify_authenticity_token,  :only   => [:create]
+  skip_before_filter :verify_authenticity_token,  :only   => [:create], raise: false
 
 
   def create

--- a/lib/opro/controllers/application_controller_helper.rb
+++ b/lib/opro/controllers/application_controller_helper.rb
@@ -11,7 +11,7 @@ module Opro
 
       included do
         around_filter      :oauth_auth!
-        skip_before_filter :verify_authenticity_token, :if => :valid_oauth?
+        skip_before_filter :verify_authenticity_token, :if => :valid_oauth?, raise: false
       end
 
       def opro_authenticate_user!


### PR DESCRIPTION
Rails 5.0 now raises an exception when `skip_before_action` (aka `skip_before_filter`) is called with a filter that does not exist (https://github.com/rails/rails/pull/19029). This causes opro to crash in some cases where before actions are skipped that may not exist. To resolve the issue, exceptions are explicitly silenced for skipped actions that may be defined elsewhere.