### PR TITLE
Rename Depricated Rails Methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ end
 ```
 
 
-Now in your controllers you can allow OAuth access using the same syntax of the rails `before_filter`
+Now in your controllers you can allow OAuth access using the same syntax of the rails `before_action`
 
 ```ruby
 class UsersController < ApplicationController
@@ -127,7 +127,7 @@ You can add custom permissions by adding to the array:
 config.request_permissions = [:write, :email, :picture, :whatever]
 ```
 
-You can then restrict access using the custom permissions by calling `require_oauth_permissions`, which takes the same arguments as `before_filter`:
+You can then restrict access using the custom permissions by calling `require_oauth_permissions`, which takes the same arguments as `before_action`:
 
 ```ruby
 require_oauth_permissions :email, :only => :index

--- a/app/controllers/opro/oauth/auth_controller.rb
+++ b/app/controllers/opro/oauth/auth_controller.rb
@@ -1,6 +1,6 @@
 class Opro::Oauth::AuthController < OproController
-  before_filter      :opro_authenticate_user!
-  before_filter      :ask_user!,                  :only   => [:create]
+  before_action      :opro_authenticate_user!
+  before_action      :ask_user!,                  :only   => [:create]
 
   def new
     @redirect_uri = params[:redirect_uri]

--- a/app/controllers/opro/oauth/client_app_controller.rb
+++ b/app/controllers/opro/oauth/client_app_controller.rb
@@ -1,5 +1,5 @@
 class Opro::Oauth::ClientAppController < OproController
-  before_filter :opro_authenticate_user!
+  before_action :opro_authenticate_user!
 
   def new
     @client_app = Opro::Oauth::ClientApp.new

--- a/app/controllers/opro/oauth/docs_controller.rb
+++ b/app/controllers/opro/oauth/docs_controller.rb
@@ -4,7 +4,7 @@ require 'kramdown'
 OPRO_MD_ROOT = File.join(File.dirname(__FILE__), '../../../views/opro/oauth/docs/markdown/')
 
 class Opro::Oauth::DocsController < OproController
-  before_filter :set_protocol!
+  before_action :set_protocol!
   helper_method :render_doc
 
   def index

--- a/app/controllers/opro/oauth/token_controller.rb
+++ b/app/controllers/opro/oauth/token_controller.rb
@@ -2,8 +2,8 @@
 # codes and refresh_tokens for access_tokens
 
 class Opro::Oauth::TokenController < OproController
-  before_filter      :opro_authenticate_user!,    :except => [:create]
-  skip_before_filter :verify_authenticity_token,  :only   => [:create]
+  before_action      :opro_authenticate_user!,    :except => [:create]
+  skip_before_action :verify_authenticity_token,  :only   => [:create]
 
 
   def create

--- a/lib/opro/controllers/application_controller_helper.rb
+++ b/lib/opro/controllers/application_controller_helper.rb
@@ -10,8 +10,8 @@ module Opro
       include Opro::Controllers::Concerns::RateLimits
 
       included do
-        around_filter      :oauth_auth!
-        skip_before_filter :verify_authenticity_token, :if => :valid_oauth?
+        around_action      :oauth_auth!
+        skip_before_action :verify_authenticity_token, :if => :valid_oauth?
       end
 
       def opro_authenticate_user!
@@ -21,12 +21,12 @@ module Opro
 
       module ClassMethods
         def allow_oauth!(options = {})
-          prepend_before_filter :allow_oauth, options
+          prepend_before_action :allow_oauth, options
         end
 
         def disallow_oauth!(options = {})
-          prepend_before_filter :disallow_oauth,  options
-          skip_before_filter    :allow_oauth,     options
+          prepend_before_action :disallow_oauth,  options
+          skip_before_action    :allow_oauth,     options
         end
 
       end

--- a/lib/opro/controllers/concerns/permissions.rb
+++ b/lib/opro/controllers/concerns/permissions.rb
@@ -66,7 +66,7 @@ module Opro::Controllers::Concerns::Permissions
     def skip_oauth_permissions(*args)
       options     = args.last.is_a?(Hash) ? callbacks.pop : {}
       permissions = args
-      prepend_before_filter(options) do
+      prepend_before_action(options) do
         permissions.each do |permission|
           controller.skip_oauth_required_permission(permission)
         end
@@ -78,7 +78,7 @@ module Opro::Controllers::Concerns::Permissions
     def require_oauth_permissions(*args)
       options     = args.last.is_a?(Hash) ? args.pop : {}
       permissions = args
-      prepend_before_filter(options) do
+      prepend_before_action(options) do
         permissions.each do |permission|
           raise "You must add #{permission.inspect} to the oPRO request_permissions setting in an initializer" unless Opro.request_permissions.include?(permission)
           controller.add_oauth_required_permission(permission)

--- a/lib/opro/controllers/concerns/rate_limits.rb
+++ b/lib/opro/controllers/concerns/rate_limits.rb
@@ -2,8 +2,8 @@ module Opro::Controllers::Concerns::RateLimits
   extend ActiveSupport::Concern
 
   included do
-    before_filter :oauth_record_rate_limit!,  :if => :valid_oauth?
-    before_filter :oauth_fail_request!,       :if => :oauth_client_over_rate_limit?
+    before_action :oauth_record_rate_limit!,  :if => :valid_oauth?
+    before_action :oauth_fail_request!,       :if => :oauth_client_over_rate_limit?
   end
 
   def oauth_client_record_access!(client_id, params)


### PR DESCRIPTION
Silences deprication warnings for methods that have been depricated in rails 5.0 and will be removed in 5.1. This includes renaming `before_filter` and `after_filter` to `before_action` and `after_action`.

The new method names were added as aliases around 4.1 so this will break compatibility with older versions of Rails. If this request is accepted a version pump should also be considered and constraints in the gemspec will need to be updated.