### PR TITLE
Rails 5 support and deprecation fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ rails = case rails_version
 when "master"
   {github: "rails/rails"}
 when "default"
-  ">= 3.1.0"
+  "~> 5.0.6"
 else
   "~> #{rails_version}"
 end
@@ -16,8 +16,10 @@ when "master"
   {github: "plataformatec/devise"}
 when /pre/
   {github: "plataformatec/devise", branch: "rails4"}
-when "3.1.0", "3.2.0", "default"
+when "3.1.0", "3.2.0"
   "~> 2.2"
+when "default"
+  "~> 4.3.0"
 end
 
 gem "rails", rails

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ end
 ```
 
 
-Now in your controllers you can allow OAuth access using the same syntax of the rails `before_filter`
+Now in your controllers you can allow OAuth access using the same syntax of the rails `before_action`
 
 ```ruby
 class UsersController < ApplicationController
@@ -127,7 +127,7 @@ You can add custom permissions by adding to the array:
 config.request_permissions = [:write, :email, :picture, :whatever]
 ```
 
-You can then restrict access using the custom permissions by calling `require_oauth_permissions`, which takes the same arguments as `before_filter`:
+You can then restrict access using the custom permissions by calling `require_oauth_permissions`, which takes the same arguments as `before_action`:
 
 ```ruby
 require_oauth_permissions :email, :only => :index

--- a/app/controllers/opro/oauth/auth_controller.rb
+++ b/app/controllers/opro/oauth/auth_controller.rb
@@ -1,6 +1,6 @@
 class Opro::Oauth::AuthController < OproController
-  before_filter      :opro_authenticate_user!
-  before_filter      :ask_user!,                  :only   => [:create]
+  before_action      :opro_authenticate_user!
+  before_action      :ask_user!,                  :only   => [:create]
 
   def new
     @redirect_uri = params[:redirect_uri]

--- a/app/controllers/opro/oauth/auth_controller.rb
+++ b/app/controllers/opro/oauth/auth_controller.rb
@@ -24,6 +24,8 @@ class Opro::Oauth::AuthController < OproController
   # When a user is sent to authorize an application they must first accept the authorization
   # if they've already authed the app, they skip this section
   def ask_user!
+    params.permit!
+
     if user_granted_access_before?(current_user, params)
       # Re-Authorize the application, do not ask the user
       params.delete(:permissions) ## Delete permissions supplied by client app, this was a security hole

--- a/app/controllers/opro/oauth/client_app_controller.rb
+++ b/app/controllers/opro/oauth/client_app_controller.rb
@@ -1,5 +1,5 @@
 class Opro::Oauth::ClientAppController < OproController
-  before_filter :opro_authenticate_user!
+  before_action :opro_authenticate_user!
 
   def new
     @client_app = Opro::Oauth::ClientApp.new

--- a/app/controllers/opro/oauth/docs_controller.rb
+++ b/app/controllers/opro/oauth/docs_controller.rb
@@ -4,7 +4,7 @@ require 'kramdown'
 OPRO_MD_ROOT = File.join(File.dirname(__FILE__), '../../../views/opro/oauth/docs/markdown/')
 
 class Opro::Oauth::DocsController < OproController
-  before_filter :set_protocol!
+  before_action :set_protocol!
   helper_method :render_doc
 
   def index

--- a/app/controllers/opro/oauth/tests_controller.rb
+++ b/app/controllers/opro/oauth/tests_controller.rb
@@ -30,7 +30,7 @@ class Opro::Oauth::TestsController < OproController
   def render_result(result)
     respond_to do |format|
       format.html do
-        render :text => result.to_json, :status => result[:status], :layout => true
+        render :html => result.to_json, :status => result[:status], :layout => true
       end
       format.json do
         render :json => result, :status => result[:status]

--- a/app/controllers/opro/oauth/token_controller.rb
+++ b/app/controllers/opro/oauth/token_controller.rb
@@ -3,7 +3,7 @@
 
 class Opro::Oauth::TokenController < OproController
   before_filter      :opro_authenticate_user!,    :except => [:create]
-  skip_before_filter :verify_authenticity_token,  :only   => [:create]
+  skip_before_filter :verify_authenticity_token,  :only   => [:create], :raise => false
 
 
   def create

--- a/app/controllers/opro/oauth/token_controller.rb
+++ b/app/controllers/opro/oauth/token_controller.rb
@@ -2,7 +2,7 @@
 # codes and refresh_tokens for access_tokens
 
 class Opro::Oauth::TokenController < OproController
-  before_filter      :opro_authenticate_user!,    :except => [:create]
+  before_action      :opro_authenticate_user!,    :except => [:create]
   skip_before_filter :verify_authenticity_token,  :only   => [:create], :raise => false
 
 

--- a/app/controllers/opro/oauth/token_controller.rb
+++ b/app/controllers/opro/oauth/token_controller.rb
@@ -3,7 +3,7 @@
 
 class Opro::Oauth::TokenController < OproController
   before_action      :opro_authenticate_user!,    :except => [:create]
-  skip_before_filter :verify_authenticity_token,  :only   => [:create], :raise => false
+  skip_before_action :verify_authenticity_token,  :only   => [:create], :raise => false
 
 
   def create

--- a/app/models/opro/oauth/auth_grant.rb
+++ b/app/models/opro/oauth/auth_grant.rb
@@ -71,6 +71,7 @@ class Opro::Oauth::AuthGrant < ActiveRecord::Base
   end
 
   def update_permissions(permissions = default_permissions)
+    permissions = permissions.to_h
     self.permissions = permissions and save if self.permissions != permissions
   end
 

--- a/lib/opro/auth_provider/devise.rb
+++ b/lib/opro/auth_provider/devise.rb
@@ -8,7 +8,7 @@ module Opro
       end
 
       def login_method(current_user)
-        controller.sign_in(current_user, :bypass => true)
+        controller.bypass_sign_in(current_user)
       end
 
       def logout_method(current_user)
@@ -21,7 +21,7 @@ module Opro
 
       def find_user_for_auth(params)
         return false if params[:password].blank?
-        find_params = params.each_with_object({}) {|(key,value), hash| hash[key] = value if ::Devise.authentication_keys.include?(key.to_sym) }
+        find_params = params.permit!.to_h.each_with_object({}) {|(key,value), hash| hash[key] = value if ::Devise.authentication_keys.include?(key.to_sym) }
         # Try to get fancy, some clients have :username hardcoded, if we have nothing in our find hash
         # we can make an educated guess here
         if find_params.blank? && params[:username].present?

--- a/lib/opro/controllers/application_controller_helper.rb
+++ b/lib/opro/controllers/application_controller_helper.rb
@@ -21,11 +21,11 @@ module Opro
 
       module ClassMethods
         def allow_oauth!(options = {})
-          prepend_before_filter :allow_oauth, options
+          prepend_before_action :allow_oauth, options
         end
 
         def disallow_oauth!(options = {})
-          prepend_before_filter :disallow_oauth,  options
+          prepend_before_action :disallow_oauth,  options
           skip_before_action    :allow_oauth,     options
         end
 

--- a/lib/opro/controllers/application_controller_helper.rb
+++ b/lib/opro/controllers/application_controller_helper.rb
@@ -11,7 +11,7 @@ module Opro
 
       included do
         around_action      :oauth_auth!
-        skip_before_filter :verify_authenticity_token, :if => :valid_oauth?, :raise => false
+        skip_before_action :verify_authenticity_token, :if => :valid_oauth?, :raise => false
       end
 
       def opro_authenticate_user!
@@ -26,7 +26,7 @@ module Opro
 
         def disallow_oauth!(options = {})
           prepend_before_filter :disallow_oauth,  options
-          skip_before_filter    :allow_oauth,     options
+          skip_before_action    :allow_oauth,     options
         end
 
       end

--- a/lib/opro/controllers/application_controller_helper.rb
+++ b/lib/opro/controllers/application_controller_helper.rb
@@ -11,7 +11,7 @@ module Opro
 
       included do
         around_filter      :oauth_auth!
-        skip_before_filter :verify_authenticity_token, :if => :valid_oauth?
+        skip_before_filter :verify_authenticity_token, :if => :valid_oauth?, :raise => false
       end
 
       def opro_authenticate_user!

--- a/lib/opro/controllers/application_controller_helper.rb
+++ b/lib/opro/controllers/application_controller_helper.rb
@@ -10,7 +10,7 @@ module Opro
       include Opro::Controllers::Concerns::RateLimits
 
       included do
-        around_filter      :oauth_auth!
+        around_action      :oauth_auth!
         skip_before_filter :verify_authenticity_token, :if => :valid_oauth?, :raise => false
       end
 

--- a/lib/opro/controllers/concerns/permissions.rb
+++ b/lib/opro/controllers/concerns/permissions.rb
@@ -66,7 +66,7 @@ module Opro::Controllers::Concerns::Permissions
     def skip_oauth_permissions(*args)
       options     = args.last.is_a?(Hash) ? callbacks.pop : {}
       permissions = args
-      prepend_before_filter(options) do
+      prepend_before_action(options) do
         permissions.each do |permission|
           controller.skip_oauth_required_permission(permission)
         end
@@ -78,7 +78,7 @@ module Opro::Controllers::Concerns::Permissions
     def require_oauth_permissions(*args)
       options     = args.last.is_a?(Hash) ? args.pop : {}
       permissions = args
-      prepend_before_filter(options) do
+      prepend_before_action(options) do
         permissions.each do |permission|
           raise "You must add #{permission.inspect} to the oPRO request_permissions setting in an initializer" unless Opro.request_permissions.include?(permission)
           controller.add_oauth_required_permission(permission)

--- a/lib/opro/controllers/concerns/permissions.rb
+++ b/lib/opro/controllers/concerns/permissions.rb
@@ -55,7 +55,7 @@ module Opro::Controllers::Concerns::Permissions
   # if client has been granted write permissions or request is a 'GET' returns true
   def oauth_client_can_write?
     return false unless oauth_access_grant.present?
-    return true if env['REQUEST_METHOD'] == 'GET'
+    return true if request.env['REQUEST_METHOD'] == 'GET'
     return true if oauth_access_grant.can?(:write)
     false
   end

--- a/lib/opro/controllers/concerns/rate_limits.rb
+++ b/lib/opro/controllers/concerns/rate_limits.rb
@@ -2,8 +2,8 @@ module Opro::Controllers::Concerns::RateLimits
   extend ActiveSupport::Concern
 
   included do
-    before_filter :oauth_record_rate_limit!,  :if => :valid_oauth?
-    before_filter :oauth_fail_request!,       :if => :oauth_client_over_rate_limit?
+    before_action :oauth_record_rate_limit!,  :if => :valid_oauth?
+    before_action :oauth_fail_request!,       :if => :oauth_client_over_rate_limit?
   end
 
   def oauth_client_record_access!(client_id, params)

--- a/test/controllers/permissions_test.rb
+++ b/test/controllers/permissions_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Opro::Oauth::TestsControllerTest < ActionController::TestCase
   tests Opro::Oauth::TestsController
-  include Devise::TestHelpers
+  include Devise::Test::ControllerHelpers
 
   setup do
     @user         = create_user
@@ -13,7 +13,7 @@ class Opro::Oauth::TestsControllerTest < ActionController::TestCase
     permissions = {'write' => true}
     @auth_grant.update_permissions(permissions)
 
-    post :create, :access_token => @auth_grant.access_token, :format => :json
+    post :create, :params => { :access_token => @auth_grant.access_token }, :format => :json
     assert_response :success
   end
 
@@ -21,7 +21,7 @@ class Opro::Oauth::TestsControllerTest < ActionController::TestCase
   test "access_token with NO write ability can NOT POST" do
     permissions = {:write => false}
     @auth_grant.update_permissions(permissions)
-    post :create, :access_token => @auth_grant.access_token, :format =>  :json
+    post :create, :params => { :access_token => @auth_grant.access_token }, :format => :json
     assert_response 401
   end
 end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -45,7 +45,5 @@ module Dummy
 
     # Configure sensitive parameters which will be filtered from the log file.
     config.filter_parameters += [:password]
-
-    config.active_record.whitelist_attributes = true
   end
 end

--- a/test/dummy/config/environments/development.rb
+++ b/test/dummy/config/environments/development.rb
@@ -22,5 +22,7 @@ Dummy::Application.configure do
 
   # Only use best-standards-support built into browsers
   config.action_dispatch.best_standards_support = :builtin
+
+  config.eager_load = false
 end
 

--- a/test/dummy/config/environments/production.rb
+++ b/test/dummy/config/environments/production.rb
@@ -46,4 +46,6 @@ Dummy::Application.configure do
 
   # Send deprecation notices to registered listeners
   config.active_support.deprecation = :notify
+
+  config.eager_load = false
 end

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -36,4 +36,6 @@ Dummy::Application.configure do
 
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
+
+  config.eager_load = true
 end

--- a/test/dummy/config/initializers/devise.rb
+++ b/test/dummy/config/initializers/devise.rb
@@ -9,9 +9,6 @@ Devise.setup do |config|
   # Configure the class responsible to send e-mails.
   # config.mailer = "Devise::Mailer"
 
-  # Automatically apply schema changes in tableless databases
-  config.apply_schema = false
-
   # ==> ORM configuration
   # Load and configure the ORM. Supports :active_record (default) and
   # :mongoid (bson_ext recommended) by default. Other ORMs may be
@@ -220,4 +217,7 @@ Devise.setup do |config|
   #   manager.intercept_401 = false
   #   manager.default_strategies(:scope => :user).unshift :some_external_strategy
   # end
+  #
+
+  config.secret_key = '056ed94d8fb2475bddc9bf3fe5bde8c807711f6cc37e4b9534e2bc022fe36eae1b13742d82acb412087ac833dd3baf19bda469f4304fef30239da4de3bacc3fe'
 end

--- a/test/dummy/config/initializers/secret_token.rb
+++ b/test/dummy/config/initializers/secret_token.rb
@@ -4,4 +4,4 @@
 # If you change this key, all old signed cookies will become invalid!
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
-Dummy::Application.config.secret_token = 'bedc31c5fff702ea808045bbbc5123455f1c00ecd005a1f667a5f04332100a6abf22cfcee2b3d39b8f677c03bb6503cf1c3b65c1287b9e13bd0d20c6431ec6ab'
+Dummy::Application.config.secret_key_base = 'bedc31c5fff702ea808045bbbc5123455f1c00ecd005a1f667a5f04332100a6abf22cfcee2b3d39b8f677c03bb6503cf1c3b65c1287b9e13bd0d20c6431ec6ab'

--- a/test/integration/action_dispatch/auth_controller_test.rb
+++ b/test/integration/action_dispatch/auth_controller_test.rb
@@ -6,12 +6,13 @@
 require 'test_helper'
 
 class AuthControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
   setup do
     @user         = create_user
     @client_app   = create_client_app
     @redirect_uri = '/'
   end
-
 
   test "AUTHORIZE: previously authed user gets Authed immediately, permissions not changed" do
     auth_grant  = create_auth_grant_for_user(@user, @client_app)
@@ -69,7 +70,6 @@ class AuthControllerTest < ActionDispatch::IntegrationTest
 
     refute auth_grant.permissions.has_key?(permissions.keys.first)
   end
-
 
   test "AUTHORIZE: user gets redirected to new form if not already authed" do
     params = { :client_id     => @client_app.client_id ,

--- a/test/integration/action_dispatch/oauth_flow_test.rb
+++ b/test/integration/action_dispatch/oauth_flow_test.rb
@@ -39,22 +39,22 @@ class OauthTokenTest < ActionDispatch::IntegrationTest
     access_token = auth_grant.access_token
 
     headers = {"HTTP_AUTHORIZATION" => "token #{access_token}"}
-    post oauth_tests_path, {}, headers
+    post oauth_tests_path, :params => {}, :headers => headers
 
     assert_equal 200, status
 
     headers = {"HTTP_AUTHORIZATION" => "Bearer #{access_token}"}
-    post oauth_tests_path, {}, headers
+    post oauth_tests_path, :params => {}, :headers => headers
 
     assert_equal 200, status
 
     headers = {"HTTP_AUTHORIZATION" => "token=\"#{access_token}\""}
-    post oauth_tests_path, {}, headers
+    post oauth_tests_path, :params => {}, :headers => headers
 
     Opro.setup {|config| config.header_auth_regex = /Zoro\s(.*)/ }
 
     headers = {"HTTP_AUTHORIZATION" => "Zoro #{access_token}"}
-    post oauth_tests_path, {}, headers
+    post oauth_tests_path, :params => {}, :headers => headers
 
     assert_equal 200, status
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -39,16 +39,19 @@ ActiveRecord::Base.logger = Logger.new(nil)
 ActiveRecord::Migrator.migrate File.expand_path("../dummy/db/migrate/", __FILE__)
 
 class ActiveSupport::TestCase
-  self.use_transactional_fixtures = true
+  # include Devise::Test::ControllerHelpers
+
+  self.use_transactional_tests = true
   self.use_instantiated_fixtures  = false
+end
+
+class ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
 end
 
 # Load support files
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
-
-
-include Devise::TestHelpers
 
 # gives us the login_as(@user) method when request object is not present
 include Warden::Test::Helpers


### PR DESCRIPTION
Rails 5 related fixes added:
* Fixing `ArgumentError: Before process_action callback :verify_authenticity_token has not been defined`.
* Replacing `before_filter` with `before_action`.
* Replacing `around_filter` with `around_action`.
* Replacing `skip_before_filter` with `skip_before_action`.
* Replacing `prepend_before_filter` with `prepend_before_action`.
* Using `request.env['REQUEST_METHOD']` instead of `env['REQUEST_METHOD']` to fix deprecation message.

Also I bumped dummy app to rails 5 version in order for tests to pass. In order to do that I also had to bump devise to "4.3.0"

Those changes will not work with apps using Rails 3.